### PR TITLE
chown before update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,5 +48,6 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               gcloud --quiet container clusters get-credentials core-scaling
+              chown -R 65534:65534 doc
               ./run.sh update
             fi


### PR DESCRIPTION
The engine sidecar container chmods before engine starts everytime, but if we update the cluster but not the engine, that container wont run and the app that `./run.sh update` pushes will be owned by root