### PR TITLE
Adding requests and limits to our services

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,3 +251,7 @@ Remove the cluster with:
 * If you are running bash for Windows, you might have an issue with incorrect paths when querying kubectl for metrics. Use CMD instead of bash for Windows.
 
 * If the cluster (API server) is unresponsive when you add load to your cluster, this is because the Kubernetes master node is being updated to match the size of the autoscaling cluster. To fix this, you have to deploy a regional cluster. Reade more here: https://cloudplatform.googleblog.com/2018/06/Regional-clusters-in-Google-Kubernetes-Engine-are-now-generally-available.html
+
+### General Notes
+
+* We have specified kubernetes requests and limits for our services. These, especially the values for the engine, should be tweaked if you use another node size.

--- a/custom-metrics-api/custom-metrics-apiserver-deployment.yaml
+++ b/custom-metrics-api/custom-metrics-apiserver-deployment.yaml
@@ -19,6 +19,11 @@ spec:
       serviceAccountName: custom-metrics-apiserver
       containers:
       - name: custom-metrics-apiserver
+        resources:
+            requests:
+              memory: "128Mi"
+            limits:
+              memory: "128Mi"
         image: quay.io/coreos/k8s-prometheus-adapter-amd64:v0.2.0
         args:
         - /adapter

--- a/grafana/grafana-dep.yaml
+++ b/grafana/grafana-dep.yaml
@@ -16,6 +16,11 @@ spec:
       containers:
         - name: grafana
           image: grafana/grafana:5.0.4
+          resources:
+              requests:
+                memory: "50Mi"
+              limits:
+                memory: "50Mi"
           env:
             - name: GF_AUTH_ANONYMOUS_ENABLED
               value: "true"

--- a/ingress/ingress-nginx-dep.yaml
+++ b/ingress/ingress-nginx-dep.yaml
@@ -37,6 +37,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          resources:
+              requests:
+                memory: "256Mi"
+              limits:
+                memory: "256Mi"
           ports:
           - name: http
             containerPort: 80

--- a/nfs-volumes/nfs-volume-deployment.yaml
+++ b/nfs-volumes/nfs-volume-deployment.yaml
@@ -17,6 +17,11 @@ spec:
       containers:
       - name: nfs-server
         image: gcr.io/google_containers/volume-nfs:0.8
+        resources:
+            requests:
+              memory: "400Mi"
+            limits:
+              memory: "400Mi"
         ports:
           - name: nfs
             containerPort: 2049

--- a/prometheus/prometheus-dep.yaml
+++ b/prometheus/prometheus-dep.yaml
@@ -22,6 +22,11 @@ spec:
       containers:
       - name: prometheus
         image: prom/prometheus:v2.1.0
+        resources:
+            requests:
+              memory: "2500Mi"
+            limits:
+              memory: "2500Mi"
         imagePullPolicy: Always
         command:
           - prometheus

--- a/qlik-core/engine-deployment.yaml
+++ b/qlik-core/engine-deployment.yaml
@@ -30,6 +30,11 @@ spec:
       containers:
       - name: engine
         image: "qlikcore/engine:12.215.0"
+        resources:
+            requests:
+              memory: "2200Mi"
+            limits:
+              memory: "2200Mi"
         args: [
           "-S", "AcceptEULA=no", # change to 'yes' if you accept the Qlik Core EULA
           "-S", "LicenseServiceUrl=http://license-service:9200",

--- a/qlik-core/license-service-deployment.yaml
+++ b/qlik-core/license-service-deployment.yaml
@@ -14,6 +14,11 @@ spec:
       containers:
       - name: license-service
         image: "qlikcore/licenses:1.0.5"
+        resources:
+            requests:
+              memory: "16Mi"
+            limits:
+              memory: "16Mi"
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 9200

--- a/qlik-core/mira-deployment.yaml
+++ b/qlik-core/mira-deployment.yaml
@@ -13,6 +13,11 @@ spec:
     spec:
       containers:
       - name: mira
+        resources:
+            requests:
+              memory: "200Mi"
+            limits:
+              memory: "200Mi"
         image: "qlikcore/mira:0.4.0"
         imagePullPolicy: IfNotPresent
         ports:

--- a/qlik-core/qix-session-deployment.yaml
+++ b/qlik-core/qix-session-deployment.yaml
@@ -16,6 +16,11 @@ spec:
     spec:
       containers:
       - name: qix-session
+        resources:
+            requests:
+              memory: "100Mi"
+            limits:
+              memory: "100Mi"
         image: "qlikcore/qix-session-placement-service:0.0.1-288"
         env:
         - name: SESSIONS_PER_ENGINE_THRESHOLD


### PR DESCRIPTION
Adding requests and limits to our services

For non engine services the limit is what they have used recently + about 20-50%

For engine it is how much that has worked reasonably with leaving some room on the node as well as allowing some other service to run on the same node, could probably be tweaked.