### PR TITLE
Use kubernetes secret instead of configmap for license-data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ jobs:
   build:
     docker:
       - image: google/cloud-sdk
+    environment:
+      TEST_CLUSTER_ZONE: europe-west3-b
     working_directory: ~/scaling
     steps:
       - checkout
@@ -14,7 +16,7 @@ jobs:
           command: |
             gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
             gcloud --quiet config set project dev-qlik-core
-            gcloud --quiet config set compute/zone europe-west2-a
+            gcloud --quiet config set compute/zone $TEST_CLUSTER_ZONE
       - run:
           name: Accept EULA
           command: grep -rl AcceptEULA ./qlik-core | xargs sed -i 's/AcceptEULA=no/AcceptEULA=yes/g'
@@ -26,7 +28,7 @@ jobs:
           environment:
             GCLOUD_NUM_NODES: 2
           command: |
-            K8S_CLUSTER=cci-cluster-$CIRCLE_BUILD_NUM DISK_NAME=$DISK_NAME_TEST-$CIRCLE_BUILD_NUM ./run.sh deploy
+            GCLOUD_ZONE=$TEST_CLUSTER_ZONE K8S_CLUSTER=cci-cluster-$CIRCLE_BUILD_NUM DISK_NAME=$DISK_NAME_TEST-$CIRCLE_BUILD_NUM ./run.sh deploy
             # Wait for all deployments to rollout
             for deployment in `kubectl get deployment -o name`; do echo `kubectl rollout status $deployment`; done
       - run:
@@ -41,7 +43,7 @@ jobs:
             npm run test
       - run:
           name: Remove test cluster
-          command: K8S_CLUSTER=cci-cluster-$CIRCLE_BUILD_NUM DISK_NAME=$DISK_NAME_TEST-$CIRCLE_BUILD_NUM ./run.sh remove
+          command: GCLOUD_ZONE=$TEST_CLUSTER_ZONE K8S_CLUSTER=cci-cluster-$CIRCLE_BUILD_NUM DISK_NAME=$DISK_NAME_TEST-$CIRCLE_BUILD_NUM ./run.sh remove
           when: always
       - run:
           name: Set Disk Name For Live Cluster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           name: Deploy qlik-core scaling example if on master
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              gcloud --quiet container clusters get-credentials core-scaling
+              gcloud --quiet container clusters get-credentials core-scaling --zone=europe-west2-a
               ./run.sh update
               POD=$(kubectl get pods --selector="role=nfs-server" -o=jsonpath='{.items[0].metadata.name}')
               kubectl exec $POD -- chown -R 65534:65534 /exports/default

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ metrics-ca-config.json
 metrics-ca.crt
 metrics-ca.key
 cm-adapter-serving-certs.yaml
-create_license-data-configmap.yml
 create_role_binding.yml
 node_modules/
 .vscode/

--- a/qlik-core/license-service-deployment.yaml
+++ b/qlik-core/license-service-deployment.yaml
@@ -27,12 +27,12 @@ spec:
         env:
         - name: LICENSES_SERIAL_NBR
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: license-data
               key: LICENSES_SERIAL_NBR
         - name: LICENSES_CONTROL_NBR
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: license-data
               key: LICENSES_CONTROL_NBR
       imagePullSecrets:

--- a/run.sh
+++ b/run.sh
@@ -47,8 +47,7 @@ function doc_seed() {
 
 function deploy_core() {
   kubectl apply -f ./rbac-config.yaml
-  kubectl create configmap license-data --from-literal LICENSES_SERIAL_NBR=$LICENSES_SERIAL_NBR --from-literal LICENSES_CONTROL_NBR=$LICENSES_CONTROL_NBR --dry-run -o=yaml > create_license-data-configmap.yml
-  kubectl apply -f create_license-data-configmap.yml
+  kubectl create secret generic license-data --from-literal LICENSES_SERIAL_NBR=$LICENSES_SERIAL_NBR --from-literal LICENSES_CONTROL_NBR=$LICENSES_CONTROL_NBR --dry-run -o=yaml | kubectl apply -f -
   kubectl apply -f ./qlik-core
 }
 


### PR DESCRIPTION
Also piped the dry-run directly to `kubectl apply` instead piping to a file.