### PR TITLE
Update engine-prestop-hook.yaml

### DIFF
--- a/qlik-core/engine-prestop-hook.yaml
+++ b/qlik-core/engine-prestop-hook.yaml
@@ -6,7 +6,7 @@ data:
   engine-prestop-hook.sh: |-
     while true
     do
-      sessionCount=$(curl --silent localhost:9090/metrics | grep -oP '(?<=qix_active_sessions )\d+(?=\.\d*)')
+      sessionCount=$(curl --silent localhost:9090/metrics | grep -oE ‘(qix_active_sessions\ [0-9]+)’ | grep -oE ‘([0-9]+)’)
       if [ "$sessionCount" -eq "0" ]
       then
         exit 0


### PR DESCRIPTION
According to Hampus `grep` inside of engine does no longer support the `-P` option and the grep has to be changed.