### PR TITLE
Upgrading and limiting logs from custom api server

### DIFF
--- a/custom-metrics-api/custom-metrics-apiserver-auth-delegator-cluster-role-binding.yaml
+++ b/custom-metrics-api/custom-metrics-apiserver-auth-delegator-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics:system:auth-delegator

--- a/custom-metrics-api/custom-metrics-apiserver-auth-reader-role-binding.yaml
+++ b/custom-metrics-api/custom-metrics-apiserver-auth-reader-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: custom-metrics-auth-reader

--- a/custom-metrics-api/custom-metrics-apiserver-deployment.yaml
+++ b/custom-metrics-api/custom-metrics-apiserver-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -24,16 +24,27 @@ spec:
               memory: "128Mi"
             limits:
               memory: "128Mi"
-        image: quay.io/coreos/k8s-prometheus-adapter-amd64:v0.2.0
+        image: quay.io/coreos/k8s-prometheus-adapter-amd64:v0.4.1
         args:
-        - /adapter
         - --secure-port=6443
         - --logtostderr=true
         - --prometheus-url=http://prometheus.monitoring.svc:9090/
         - --metrics-relist-interval=30s
-        - --rate-interval=5m
-        - --v=10
+        - --v=2
+        - --config=/etc/adapter/config.yaml
         ports:
         - containerPort: 6443
         securityContext:
           runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/adapter/
+          name: config
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp-vol
+      volumes:
+      - name: config
+        configMap:
+          name: adapter-config
+      - name: tmp-vol
+        emptyDir: {}

--- a/custom-metrics-api/custom-metrics-apiserver-resource-reader-cluster-role-binding.yaml
+++ b/custom-metrics-api/custom-metrics-apiserver-resource-reader-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-api/custom-metrics-cluster-role.yaml
+++ b/custom-metrics-api/custom-metrics-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: custom-metrics-server-resources

--- a/custom-metrics-api/custom-metrics-config-map.yaml
+++ b/custom-metrics-api/custom-metrics-config-map.yaml
@@ -1,0 +1,98 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: adapter-config
+  namespace: monitoring
+data:
+  config.yaml: |
+    rules:
+    - seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
+      seriesFilters: []
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod_name:
+            resource: pod
+      name:
+        matches: ^container_(.*)_seconds_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[1m])) by (<<.GroupBy>>)
+    - seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
+      seriesFilters:
+      - isNot: ^container_.*_seconds_total$
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod_name:
+            resource: pod
+      name:
+        matches: ^container_(.*)_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}[1m])) by (<<.GroupBy>>)
+    - seriesQuery: '{__name__=~"^container_.*",container_name!="POD",namespace!="",pod_name!=""}'
+      seriesFilters:
+      - isNot: ^container_.*_total$
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod_name:
+            resource: pod
+      name:
+        matches: ^container_(.*)$
+        as: ""
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,container_name!="POD"}) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters:
+      - isNot: .*_total$
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ""
+        as: ""
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters:
+      - isNot: .*_seconds_total
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ^(.*)_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters: []
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ^(.*)_seconds_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
+    resourceRules:
+      cpu:
+        containerQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)
+        nodeQuery: sum(rate(container_cpu_usage_seconds_total{<<.LabelMatchers>>, id='/'}[1m])) by (<<.GroupBy>>)
+        resources:
+          overrides:
+            instance:
+              resource: node
+            namespace:
+              resource: namespace
+            pod_name:
+              resource: pod
+        containerLabel: container_name
+      memory:
+        containerQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+        nodeQuery: sum(container_memory_working_set_bytes{<<.LabelMatchers>>,id='/'}) by (<<.GroupBy>>)
+        resources:
+          overrides:
+            instance:
+              resource: node
+            namespace:
+              resource: namespace
+            pod_name:
+              resource: pod
+        containerLabel: container_name
+      window: 1m

--- a/custom-metrics-api/custom-metrics-resource-reader-cluster-role.yaml
+++ b/custom-metrics-api/custom-metrics-resource-reader-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: custom-metrics-resource-reader

--- a/custom-metrics-api/hpa-custom-metrics-cluster-role-binding.yaml
+++ b/custom-metrics-api/hpa-custom-metrics-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: hpa-controller-custom-metrics

--- a/grafana/grafana-dep.yaml
+++ b/grafana/grafana-dep.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grafana

--- a/ingress/ingress-nginx-dep.yaml
+++ b/ingress/ingress-nginx-dep.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller

--- a/ingress/ingress-nginx-rbac.yaml
+++ b/ingress/ingress-nginx-rbac.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: nginx-ingress-clusterrole
@@ -63,7 +63,7 @@ rules:
     verbs:
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: nginx-ingress-role
@@ -107,7 +107,7 @@ rules:
     verbs:
       - get
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: nginx-ingress-role-nisa-binding
@@ -124,7 +124,7 @@ subjects:
     name: nginx-ingress-serviceaccount
     namespace: ingress-nginx
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nginx-ingress-clusterrole-nisa-binding

--- a/nfs-volumes/nfs-volume-deployment.yaml
+++ b/nfs-volumes/nfs-volume-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nfs-server

--- a/prometheus/prometheus-rbac.yaml
+++ b/prometheus/prometheus-rbac.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -26,7 +26,7 @@ metadata:
   name: prometheus
   namespace: monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus

--- a/qlik-core/engine-deployment.yaml
+++ b/qlik-core/engine-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: engine
@@ -6,6 +6,9 @@ metadata:
     app: engine
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: engine
   template:
     metadata:
       labels:

--- a/qlik-core/engine-hpa-custom.yaml
+++ b/qlik-core/engine-hpa-custom.yaml
@@ -4,7 +4,7 @@ metadata:
   name: engine
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: engine
   minReplicas: 2

--- a/qlik-core/license-service-deployment.yaml
+++ b/qlik-core/license-service-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: license-service
@@ -6,6 +6,9 @@ metadata:
     app: license-service
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: license-service
   template:
     metadata:
       labels:

--- a/qlik-core/mira-deployment.yaml
+++ b/qlik-core/mira-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mira
@@ -6,6 +6,9 @@ metadata:
     app: mira
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: mira
   template:
     metadata:
       labels:

--- a/qlik-core/qix-session-deployment.yaml
+++ b/qlik-core/qix-session-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: qix-session
@@ -6,6 +6,9 @@ metadata:
     app: qix-session
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: qix-session
   template:
     metadata:
       labels:


### PR DESCRIPTION
- Upgrading from an old alpha version of Prometheus-adapter(custom metrics api server)
- Limiting the logs from Prometheus-adapter, so it's not producing gigabytes of log data #106 
- Updating apiversions on Deployment and Rbac to use later api versions. Now we are dependent on Kubernetes 1.9 and above. 
