### PR TITLE
Bump qix-session-placement-service

### DIFF
--- a/qlik-core/qix-session-deployment.yaml
+++ b/qlik-core/qix-session-deployment.yaml
@@ -24,7 +24,7 @@ spec:
               memory: "100Mi"
             limits:
               memory: "100Mi"
-        image: "qlikcore/qix-session-placement-service:0.0.1-288"
+        image: "qlikcore/qix-session-placement-service:0.0.1-406"
         env:
         - name: SESSIONS_PER_ENGINE_THRESHOLD
           value: "500"


### PR DESCRIPTION
Prometheus is currently logging errors due to incorrect timestamps on metrics from the qix-session service. This version of the service does not set a timestamp on the metrics.