### PR TITLE
Switch to using signed license key

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Now that the GKE cluster is set up and the documents are loaded into the cluster
 1. Add a configmap with your license data
 
     ```bash
-    kubectl create configmap license-data-v2 --from-literal LICENSE_KEY_=YOUR-LICENSE-KEY
+    kubectl create configmap license-data --from-literal LICENSE_KEY_=YOUR-LICENSE-KEY
     ```
 
 1. Deploy Qlik Core:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Now that the GKE cluster is set up and the documents are loaded into the cluster
 1. Add a configmap with your license data
 
     ```bash
-    kubectl create configmap license-data --from-literal LICENSES_SERIAL_NBR=YOUR-LICENSE-SERIAL-NBR --from-literal LICENSES_CONTROL_NBR=YOUR-LICENSE-CONTROL-NBR
+    kubectl create configmap license-data-v2 --from-literal LICENSE_KEY_=YOUR-LICENSE-KEY
     ```
 
 1. Deploy Qlik Core:

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Now that the GKE cluster is set up and the documents are loaded into the cluster
 1. Add a configmap with your license data
 
     ```bash
-    kubectl create configmap license-data --from-literal LICENSE_KEY_=YOUR-LICENSE-KEY
+    kubectl create configmap license-data --from-literal LICENSE_KEY=YOUR-LICENSE-KEY
     ```
 
 1. Deploy Qlik Core:

--- a/charts/qlik-core/templates/license-service-deployment.yaml
+++ b/charts/qlik-core/templates/license-service-deployment.yaml
@@ -30,15 +30,10 @@ spec:
         ports:
         - containerPort: {{ .Values.licenseService.port }}
         env:
-        - name: LICENSES_SERIAL_NBR
+        - name: LICENSE_KEY
           valueFrom:
             secretKeyRef:
-              name: license-data
-              key: LICENSES_SERIAL_NBR
-        - name: LICENSES_CONTROL_NBR
-          valueFrom:
-            secretKeyRef:
-              name: license-data
-              key: LICENSES_CONTROL_NBR
+              name: license-data-v2
+              key: LICENSE_KEY
       imagePullSecrets:
       - name: dockerhub

--- a/charts/qlik-core/templates/license-service-deployment.yaml
+++ b/charts/qlik-core/templates/license-service-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: LICENSE_KEY
           valueFrom:
             secretKeyRef:
-              name: license-data-v2
+              name: license-data
               key: LICENSE_KEY
       imagePullSecrets:
       - name: dockerhub

--- a/charts/qlik-core/values.yaml
+++ b/charts/qlik-core/values.yaml
@@ -11,7 +11,7 @@ engine:
   annotations:
     prometheus.io/scrape: 'true'
     prometheus.io/port: '9090'
-  resources: 
+  resources:
   volumeMounts:
     - mountPath: /doc
       name: app-nfs
@@ -88,7 +88,7 @@ licenseService:
   name: license-service
   image:
     repository: qlikcore/licenses
-    tag: 1.1.4
+    tag: 1.37.0
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/run.sh
+++ b/run.sh
@@ -47,7 +47,7 @@ function copy_apps() {
 
 function upgrade() {
   # set up licensing info/secret
-  kubectl create secret generic license-data-v2 --from-literal LICENSE_KEY=$LICENSE_KEY --dry-run -o=yaml | kubectl apply -f -
+  kubectl create secret generic license-data --from-literal LICENSE_KEY=$LICENSE_KEY --dry-run -o=yaml | kubectl apply -f -
 
   # configuration
   kubectl apply -f ./config/grafana-datasources-cfg.yaml

--- a/run.sh
+++ b/run.sh
@@ -47,7 +47,7 @@ function copy_apps() {
 
 function upgrade() {
   # set up licensing info/secret
-  kubectl create secret generic license-data --from-literal LICENSES_SERIAL_NBR=$LICENSES_SERIAL_NBR --from-literal LICENSES_CONTROL_NBR=$LICENSES_CONTROL_NBR --dry-run -o=yaml | kubectl apply -f -
+  kubectl create secret generic license-data-v2 --from-literal LICENSE_KEY=$LICENSE_KEY --dry-run -o=yaml | kubectl apply -f -
 
   # configuration
   kubectl apply -f ./config/grafana-datasources-cfg.yaml

--- a/settings.config
+++ b/settings.config
@@ -9,7 +9,6 @@ GCLOUD_SCOPES="gke-default"
 GCLOUD_NUM_NODES="${GCLOUD_NUM_NODES:-3}"
 GCLOUD_MIN_NODES="${GCLOUD_MIN_NODES:-2}"
 GCLOUD_MAX_NODES="${GCLOUD_MAX_NODES:-6}"
-LICENSES_SERIAL_NBR="${LICENSES_SERIAL_NBR:-my-license-serial-nbr}"
-LICENSES_CONTROL_NBR="${LICENSES_CONTROL_NBR:-my-license-control-nbr}"
+LICENSE_KEY="${LICENSE_KEY:-my-license-key}"
 # When setting DISK_NAME make sure to update ./nfs-volumes/nfs-volume-deployment.yaml as well. 
 DISK_NAME="${DISK_NAME:-my-disk}"


### PR DESCRIPTION
This PR switches to using a signed license key instead of serial and control number. Also bumped the `licenses` service version to `1.37.0` to include the support for signed LEFs.

This closes #149 